### PR TITLE
Some features and suggestions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E111, E501

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -51,16 +51,15 @@ def get_breadcrumb(view, points, regex, limit):
 
 
 def make_breadcrumbs(view, shorten):
+  if len(view.sel()) == 0:
+    return
+
   settings = sublime.load_settings('Breadcrumbs.sublime-settings')
   tab_size = get_tab_size(view)
   breadcrumb_regex = settings.get('breadcrumb_regex', u'^\s*(?P<name>.*\\S)')
   separator = settings.get('breadcrumbs_separator', u' › ')
   breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)
   total_breadcrumbs_length_limit = settings.get('total_breadcrumbs_length_limit', 200)
-
-  if len(view.sel()) == 0:
-    return
-
   current_row = view.rowcol(view.sel()[0].b)[0]
 
   def get_row_start(row):

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -48,7 +48,7 @@ def get_breadcrumb(view, points, regex, limit):
     return ''
 
 
-def make_breadcrumbs(view, current_row, shorten):
+def make_breadcrumbs(view, current_row, shorten=False):
   if len(view.sel()) == 0:
     return
 
@@ -141,10 +141,10 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
     if statusbar_enabled:
       separator = settings.get('breadcrumbs_separator', u' › ')
       current_row = view.rowcol(view.sel()[0].b)[0]
-      breadcrumbs = make_breadcrumbs(view, current_row, False)
+      breadcrumbs = make_breadcrumbs(view, current_row)
 
       if breadcrumbs is not None and len(breadcrumbs) > 0:
-        view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view, current_row, True)))
+        view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view, current_row, shorten=True)))
 
 
 class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
@@ -172,7 +172,7 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
     separator = settings.get('breadcrumbs_separator', u' › ')
     view = self.view
     current_row = view.rowcol(view.sel()[0].b)[0]
-    breadcrumbs = make_breadcrumbs(view, current_row, False)
+    breadcrumbs = make_breadcrumbs(view, current_row)
     escaped_crumbs = []
     if len(breadcrumbs) > 0:
       for crumb in breadcrumbs:

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -11,6 +11,8 @@ try:
 except NameError:
   xrange = range
 
+settings = sublime.load_settings('Breadcrumbs.sublime-settings')
+
 def get_tab_size(view):
   return int(view.settings().get('tab_size', 8))
 
@@ -48,7 +50,6 @@ def get_breadcrumb(view, points, regex, separator):
 
 def make_breadcrumbs(view):
   tab_size = get_tab_size(view)
-  settings = sublime.load_settings('Breadcrumbs.sublime-settings')
   my_regex = settings.get('breadcrumbs_regex', u'(?P<name>.*)')
   breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)
   separator = settings.get('breadcrumbs_separator', u' › ')
@@ -174,8 +175,10 @@ template = '''
 class BreadcrumbsCommand(sublime_plugin.EventListener):
 
   def on_selection_modified_async(self, view):
-    view.set_status('breadcrumbs', make_breadcrumbs(view))
-
+    if settings.get('breadcrumbs_statusbar', True):
+      view.set_status('breadcrumbs', make_breadcrumbs(view))
+    else:
+      view.erase_status('breadcrumbs')
 
 class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
 

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -56,9 +56,9 @@ def make_breadcrumbs(view, current_row, shorten=False):
 
   settings = sublime.load_settings('Breadcrumbs.sublime-settings')
   tab_size = get_tab_size(view)
-  default_breadcrumb_regex = settings.get('breadcrumb_regex', u'')
+  default_breadcrumb_regex = settings.get('breadcrumb_regex', u'(?P<name>.*)')
   breadcrumb_regex = view.settings().get('breadcrumb_regex', default_breadcrumb_regex)
-  separator = settings.get('breadcrumbs_separator', u' › ')
+  separator = settings.get('breadcrumbs_separator', u' ')
   breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)
   total_breadcrumbs_length_limit = settings.get('total_breadcrumbs_length_limit', 200)
 
@@ -140,7 +140,7 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
     statusbar_enabled = view.settings().get('show_breadcrumbs_in_statusbar', default_statusbar_enabled)
 
     if statusbar_enabled:
-      separator = settings.get('breadcrumbs_separator', u' › ')
+      separator = settings.get('breadcrumbs_separator', u' ')
       current_row = view.rowcol(view.sel()[0].b)[0]
       breadcrumbs = make_breadcrumbs(view, current_row, shorten=True)
 
@@ -170,7 +170,7 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
     '''
 
     settings = sublime.load_settings('Breadcrumbs.sublime-settings')
-    separator = settings.get('breadcrumbs_separator', u' › ')
+    separator = settings.get('breadcrumbs_separator', u' ')
     view = self.view
     current_row = view.rowcol(view.sel()[0].b)[0]
     breadcrumbs = make_breadcrumbs(view, current_row)

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -123,7 +123,7 @@ def make_breadcrumbs(view, current_row, shorten):
 
 
 def copy(view, text):
-  sublime.set_clipboard(text)
+  sublime.set_clipboard(html.parser.HTMLParser().unescape(text))
   view.hide_popup()
   sublime.status_message('Breadcrumbs copied to clipboard')
 
@@ -178,7 +178,7 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
 
     body = template.format(
         breadcrumbs=breadcrumbs_element,
-        breadcrumbs_string=separator.join(breadcrumbs),
+        breadcrumbs_string=html.escape(separator.join(breadcrumbs), quote=True),
         stylesheet=stylesheet
     )
     view.show_popup(body, max_width=512, on_navigate=lambda x: copy(view, x))

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -158,6 +158,12 @@ class BreadcrumbsEventListener(sublime_plugin.EventListener):
 class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
 
   def run(self, edit):
+
+    '''
+    Built to look and work like the ShowScopeName command's popup
+    See show_scope_name.py in the Default package
+    '''
+
     stylesheet = '''
       p {
         margin-top: 0;

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -240,11 +240,11 @@ else:
       self.view.erase_phantoms('breadcrumbs')
       self.phantoms_visible = False
 
-    def navigate(self, href, string):
+    def navigate(self, href, breadcrumbs_string):
       if href == 'close':
         self.close()
       else:
-        copy(self.view, string)
+        copy(self.view, breadcrumbs_string)
 
     def run(self, edit):
       if self.phantoms_visible:
@@ -339,8 +339,8 @@ else:
             region,
             body,
             sublime.LAYOUT_BLOCK,
-            on_navigate=lambda href,
-            string=breadcrumbs_string: self.navigate(href, breadcrumbs_string)
+            on_navigate=lambda href, breadcrumbs_string=breadcrumbs_string:
+                self.navigate(href, breadcrumbs_string)
         )
         phantoms.append(phantom)
 

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -3,8 +3,11 @@ import re
 import sublime
 import sublime_plugin
 
+minihtml_available = False
+
 if int(sublime.version()) > 3124:
   import html
+  minihtml_available = True
 
 try:
   xrange
@@ -206,7 +209,7 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
     )
 
   def is_visible(self):
-    return int(sublime.version()) > 3124
+    return minihtml_available
 
 
 class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
@@ -327,4 +330,4 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     self.phantoms_visible = True
 
   def is_visible(self):
-    return int(sublime.version()) > 3124
+    return minihtml_available

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -156,7 +156,7 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
     settings = sublime.load_settings('Breadcrumbs.sublime-settings')
     if settings.get('breadcrumbs_statusbar', True):
       separator = settings.get('breadcrumbs_separator', u' › ')
-      view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view) + ['']).rstrip(separator))
+      view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view)))
     else:
       view.erase_status('breadcrumbs')
 
@@ -174,7 +174,7 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
 
     body = template.format(
         breadcrumbs=breadcrumbs_element,
-        breadcrumbs_string=separator.join(breadcrumbs + ['']).rstrip(separator),
+        breadcrumbs_string=separator.join(breadcrumbs),
         stylesheet=stylesheet
     )
     self.view.show_popup(body, max_width=512, on_navigate=lambda x: copy(self.view, x))

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -141,10 +141,10 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
     if statusbar_enabled:
       separator = settings.get('breadcrumbs_separator', u' › ')
       current_row = view.rowcol(view.sel()[0].b)[0]
-      breadcrumbs = make_breadcrumbs(view, current_row)
+      breadcrumbs = make_breadcrumbs(view, current_row, shorten=True)
 
       if breadcrumbs is not None and len(breadcrumbs) > 0:
-        view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view, current_row, shorten=True)))
+        view.set_status('breadcrumbs', separator.join(breadcrumbs))
 
 
 class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -132,12 +132,17 @@ def copy(view, text):
 class BreadcrumbsCommand(sublime_plugin.EventListener):
 
   def on_selection_modified(self, view):
-    settings = sublime.load_settings('Breadcrumbs.sublime-settings')
     view.erase_status('breadcrumbs')
-    if settings.get('breadcrumbs_statusbar', True):
+
+    settings = sublime.load_settings('Breadcrumbs.sublime-settings')
+    default_statusbar_enabled = settings.get('show_breadcrumbs_in_statusbar', True)
+    statusbar_enabled = view.settings().get('show_breadcrumbs_in_statusbar', default_statusbar_enabled)
+
+    if statusbar_enabled:
       separator = settings.get('breadcrumbs_separator', u' › ')
       current_row = view.rowcol(view.sel()[0].b)[0]
       breadcrumbs = make_breadcrumbs(view, current_row, False)
+
       if breadcrumbs is not None and len(breadcrumbs) > 0:
         view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view, current_row, True)))
 

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -175,7 +175,7 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
     escaped_crumbs = []
     if len(breadcrumbs) > 0:
       for crumb in breadcrumbs:
-        escaped_crumbs.append(html.escape(crumb))
+        escaped_crumbs.append(html.escape(crumb, quote=False))
       breadcrumbs_element = '<br>'.join(escaped_crumbs)
     else:
       breadcrumbs_element = '<em>None</em>'

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -167,7 +167,7 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
     breadcrumbs = make_breadcrumbs(self.view)
     settings = sublime.load_settings('Breadcrumbs.sublime-settings')
     separator = settings.get('breadcrumbs_separator', u' › ')
-    if len(breadcrumbs) > 1:
+    if len(breadcrumbs) > 0:
       breadcrumbs_element = '<br>'.join(breadcrumbs + [''])
     else:
       breadcrumbs_element = '<em>None</em>'

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -186,7 +186,11 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
         breadcrumbs=breadcrumbs_element,
         stylesheet=stylesheet
     )
-    view.show_popup(body, max_width=512, on_navigate=copy(view, breadcrumbs_string))
+    view.show_popup(
+        body,
+        max_width=512,
+        on_navigate=lambda x: copy(view, breadcrumbs_string)
+    )
 
   def is_visible(self):
     return int(sublime.version()) > 3124

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -138,7 +138,7 @@ def copy(view, text):
   sublime.status_message('Breadcrumbs copied to clipboard')
 
 
-class BreadcrumbsCommand(sublime_plugin.EventListener):
+class BreadcrumbsEventListener(sublime_plugin.EventListener):
 
   def on_selection_modified(self, view):
     view.erase_status('breadcrumbs')

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -149,7 +149,7 @@ stylesheet = '''
     }
     div.phantom strong {
       color:color(var(--base-bg) blend(var(--foreground) 30%));
-      padding: 0.4rem 0.7rem 0.4rem 0.7rem;
+      padding: 0.4rem 0 0.4rem 0.7rem;
     }
     div.phantom .crumb {
       padding: 0.4rem 0.7rem 0.4rem 0.7rem;

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import re
-import html
 
 import sublime
 import sublime_plugin
@@ -126,59 +125,27 @@ def make_breadcrumbs(view):
   return breadcrumbs
 
 
+def copy(view, text):
+  sublime.set_clipboard(text)
+  view.hide_popup()
+  sublime.status_message('Breadcrumbs copied to clipboard')
+
+
 stylesheet = '''
-  <style>
-    html {
-      --base-bg: color(var(--bluish) blend(var(--background) 30%));
-      --accent-bg: color(var(--base-bg) blend(var(--foreground) 60%));
-    }
-    div.phantom-arrow {
-      border-top: 0.4rem solid transparent;
-      border-left: 0.5rem solid var(--base-bg);
-      width: 0;
-      height: 0;
-    }
-    div.phantom {
-      margin: 0 0 0.2rem;
-      padding: 0.4rem 0;
-      border-radius: 0 0.2rem 0.2rem 0.2rem;
-      background-color: var(--base-bg);
-    }
-    div.phantom a {
-      text-decoration: inherit;
-    }
-    div.phantom strong {
-      color:color(var(--base-bg) blend(var(--foreground) 30%));
-      padding: 0.4rem 0 0.4rem 0.7rem;
-    }
-    div.phantom .crumb {
-      padding: 0.4rem 0.7rem 0.4rem 0.7rem;
-      border-right: 1px solid var(--accent-bg);
-    }
-    div.phantom a.close {
-      padding: 0.35rem 0.7rem 0.45rem 0.8rem;
-      position: relative;
-      bottom: 0.05rem;
-      border-radius: 0 0.2rem 0.2rem 0;
-      font-weight: bold;
-    }
-    html.dark div.phantom a.close {
-      background-color: #00000018;
-    }
-    html.light div.phantom a.close {
-      background-color: #ffffff18;
-    }
-  </style>
+  p {
+    margin-top: 0;
+  }
+  a {
+    font-family: system;
+    font-size: 1.05rem;
+  }
 '''
 
-
 template = '''
-  <body id="inline-breadcrumbs">
-    {stylesheet}
-    <div class="phantom-arrow"></div>
-    <div class="phantom">
-      <strong>Breadcrumbs:</strong><span>{breadcrumbs}</span><a class="close" href="close">''' + chr(0x00D7) + '''</a>
-    </div>
+  <body id=show-scope>
+      <style>{stylesheet}</style>
+      <p>{breadcrumbs}</p>
+      <a href="{breadcrumbs_string}">Copy</a>
   </body>
 '''
 
@@ -189,39 +156,28 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
     settings = sublime.load_settings('Breadcrumbs.sublime-settings')
     if settings.get('breadcrumbs_statusbar', True):
       separator = settings.get('breadcrumbs_separator', u' › ')
-      view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view) + ['']))
+      view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view) + ['']).rstrip(separator))
     else:
       view.erase_status('breadcrumbs')
 
 
-class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
-
-  def __init__(self, view):
-    self.view = view
-    self.phantom_set = sublime.PhantomSet(view, 'breadcrumbs')
-
-  def on_phantom_close(self, href):
-    self.view.erase_phantoms('breadcrumbs')
+class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
 
   def run(self, edit):
-    phantoms = []
-    self.view.erase_phantoms('breadcrumbs')
+    breadcrumbs = make_breadcrumbs(self.view)
+    settings = sublime.load_settings('Breadcrumbs.sublime-settings')
+    separator = settings.get('breadcrumbs_separator', u' › ')
+    if len(breadcrumbs) > 1:
+      breadcrumbs_element = '<br>'.join(breadcrumbs + [''])
+    else:
+      breadcrumbs_element = '<em>None</em>'
 
-    for region in self.view.sel():
-      line = self.view.line(region)
-      (row, col) = self.view.rowcol(region.begin())
-
-      crumb_elements = []
-      for crumb in make_breadcrumbs(self.view):
-        crumb_elements.append('<span class="crumb">' + html.escape(crumb, quote=False) + '</span>')
-
-      body = template.format(
-          breadcrumbs=''.join(crumb_elements),
-          stylesheet=stylesheet
-      )
-      phantom = sublime.Phantom(line, body, sublime.LAYOUT_BLOCK, self.on_phantom_close)
-      phantoms.append(phantom)
-    self.phantom_set.update(phantoms)
+    body = template.format(
+        breadcrumbs=breadcrumbs_element,
+        breadcrumbs_string=separator.join(breadcrumbs + ['']).rstrip(separator),
+        stylesheet=stylesheet
+    )
+    self.view.show_popup(body, max_width=512, on_navigate=lambda x: copy(self.view, x))
 
   def is_visible(self):
     return int(sublime.version()) > 3124

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -165,7 +165,7 @@ stylesheet = '''
 
 
 template = '''
-  <body>
+  <body id="inline-breadcrumbs">
     {stylesheet}
     <div class="phantom-arrow"></div>
     <div class="phantom">

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -56,7 +56,7 @@ def make_breadcrumbs(view, current_row, shorten=False):
 
   settings = sublime.load_settings('Breadcrumbs.sublime-settings')
   tab_size = get_tab_size(view)
-  default_breadcrumb_regex = settings.get('breadcrumb_regex', u'^\s*(?P<name>.*\\S)')
+  default_breadcrumb_regex = settings.get('breadcrumb_regex', u'')
   breadcrumb_regex = view.settings().get('breadcrumb_regex', default_breadcrumb_regex)
   separator = settings.get('breadcrumbs_separator', u' › ')
   breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -250,11 +250,11 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     self.view.erase_phantoms('breadcrumbs')
     self.phantoms_visible = False
 
-  def navigate(self, href, breadcrumbs_string):
+  def navigate(self, href, string):
     if href == 'close':
       self.close()
     else:
-      copy(self.view, breadcrumbs_string)
+      copy(self.view, string)
 
   def run(self, edit):
     if self.phantoms_visible:
@@ -349,7 +349,8 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
           region,
           body,
           sublime.LAYOUT_BLOCK,
-          on_navigate=lambda href, breadcrumbs_string=breadcrumbs_string: self.navigate(href, breadcrumbs_string)
+          on_navigate=lambda href,
+          string=breadcrumbs_string: self.navigate(href, breadcrumbs_string)
       )
       phantoms.append(phantom)
 

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -54,7 +54,8 @@ def make_breadcrumbs(view, current_row, shorten):
 
   settings = sublime.load_settings('Breadcrumbs.sublime-settings')
   tab_size = get_tab_size(view)
-  breadcrumb_regex = settings.get('breadcrumb_regex', u'^\s*(?P<name>.*\\S)')
+  default_breadcrumb_regex = settings.get('breadcrumb_regex', u'^\s*(?P<name>.*\\S)')
+  breadcrumb_regex = view.settings().get('breadcrumb_regex', default_breadcrumb_regex)
   separator = settings.get('breadcrumbs_separator', u' › ')
   breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)
   total_breadcrumbs_length_limit = settings.get('total_breadcrumbs_length_limit', 200)

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -3,13 +3,15 @@ import re
 import sublime
 import sublime_plugin
 
-minihtml_available = False
-viewevents_available = False
 
 if int(sublime.version()) > 3124:
   import html
   minihtml_available = True
   viewevents_available = True
+else:
+  minihtml_available = False
+  viewevents_available = False
+
 
 try:
   xrange

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -40,14 +40,12 @@ def is_white_row(view, points):
 
 
 def get_breadcrumb(view, points, regex, limit):
-  for pt in points:
-    ch = view.substr(pt)
-    if not ch.isspace():
-      linestring = view.substr(sublime.Region(pt, min(view.line(pt).b, pt + limit)))
-      match = re.search(regex, linestring)
-      if match:
-        return(match.group('name'))
-  return ''
+  linestring = view.substr(sublime.Region(min(points), min(view.line(min(points)).b, min(points) + limit)))
+  match = re.search(regex, linestring)
+  if match:
+    return(match.group('name'))
+  else:
+    return ''
 
 
 def make_breadcrumbs(view, current_row, shorten):

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
 import html
-import html.parser
 
 import sublime
 import sublime_plugin
@@ -124,7 +123,7 @@ def make_breadcrumbs(view, current_row, shorten):
 
 
 def copy(view, text):
-  sublime.set_clipboard(html.parser.HTMLParser().unescape(text))
+  sublime.set_clipboard(text)
   view.hide_popup()
   sublime.status_message('Breadcrumbs copied to clipboard')
 
@@ -163,7 +162,7 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
       <body id=show-scope>
           <style>{stylesheet}</style>
           <p>{breadcrumbs}</p>
-          <a href="{breadcrumbs_string}">Copy</a>
+          <a href="copy">Copy</a>
       </body>
     '''
 
@@ -177,12 +176,12 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
     else:
       breadcrumbs_element = '<em>None</em>'
 
+    breadcrumbs_string = separator.join(breadcrumbs)
     body = template.format(
         breadcrumbs=breadcrumbs_element,
-        breadcrumbs_string=html.escape(separator.join(breadcrumbs), quote=True),
         stylesheet=stylesheet
     )
-    view.show_popup(body, max_width=512, on_navigate=lambda x: copy(view, x))
+    view.show_popup(body, max_width=512, on_navigate=copy(view, breadcrumbs_string))
 
   def is_visible(self):
     return int(sublime.version()) > 3124

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -213,30 +213,21 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
         html {
           --base-bg: color(var(--bluish) blend(var(--background) 30%));
           --accent-bg: color(var(--base-bg) blend(var(--foreground) 90%));
-        }
-        div.phantom-arrow {
-          border-top: 0.4rem solid transparent;
-          border-left: 0.5rem solid var(--base-bg);
-          width: 0;
-          height: 0;
+          line-height: 20px;
         }
         div.phantom {
-          margin: 0 0 0.2rem;
-          border-radius: 0 0.2rem 0.2rem 0.2rem;
+          margin: 0;
         }
-        div.phantom a {
-          text-decoration: inherit;
-        }
-       .crumb {
-          line-height: 2rem;
-          padding-right: 1rem;
+        .crumb {
+          line-height: 2em;
+          padding-right: 6px;
         }
         .separator {
-          border: 1rem solid;
-          width:0;
-          height:0;
-          font-size:1rem;
-          line-height:0px;
+          border: 1em solid;
+          width: 0;
+          height: 0;
+          font-size: inherit;
+          line-height: 0px;
         }
         .crumb-1,
         .separator-1 {
@@ -255,14 +246,15 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
           border-left-color: var(--base-bg);
         }
         div.phantom a {
+          text-decoration: inherit;
           vertical-align: middle;
-          line-height: 2rem;
-          padding: 0 0.7rem 0 0.8rem;
+          line-height: 2em;
+          padding: 0 7px 0 12px;
           background-color: var(--base-bg);
         }
         div.phantom a.close {
-          border-radius: 0 0.2rem 0.2rem 0;
           font-weight: bold;
+          padding-left: 4px;
         }
       </style>
     '''
@@ -270,7 +262,6 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     template = '''
       <body id="inline-breadcrumbs">
         {stylesheet}
-        <div class="phantom-arrow"></div>
         <div class="phantom">{breadcrumbs}<a href="{breadcrumbs_string}">Copy</a><a class="close" href="close">''' + chr(0x00D7) + '''</a></div>
       </body>
     '''
@@ -294,7 +285,7 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
       phantom = sublime.Phantom(
           region,
           body,
-          sublime.LAYOUT_BELOW,
+          sublime.LAYOUT_BLOCK,
           self.close_phantoms
       )
       phantoms.append(phantom)

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -196,6 +196,8 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     self.phantom_set = sublime.PhantomSet(view, 'breadcrumbs')
 
   def close_phantoms(self, href):
+    if href is not 'close':
+      copy(self.view, href)
     self.view.erase_phantoms('breadcrumbs')
     self.phantoms_visible = False
 
@@ -252,13 +254,15 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
           border-color: var(--accent-bg);
           border-left-color: var(--base-bg);
         }
-        div.phantom a.close {
+        div.phantom a {
           vertical-align: middle;
           line-height: 2rem;
           padding: 0 0.7rem 0 0.8rem;
+          background-color: var(--base-bg);
+        }
+        div.phantom a.close {
           border-radius: 0 0.2rem 0.2rem 0;
           font-weight: bold;
-          background-color: var(--base-bg);
         }
       </style>
     '''
@@ -267,10 +271,11 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
       <body id="inline-breadcrumbs">
         {stylesheet}
         <div class="phantom-arrow"></div>
-        <div class="phantom">{breadcrumbs}<a class="close" href="close">''' + chr(0x00D7) + '''</a></div>
+        <div class="phantom">{breadcrumbs}<a href="{breadcrumbs_string}">Copy</a><a class="close" href="close">''' + chr(0x00D7) + '''</a></div>
       </body>
     '''
-
+    settings = sublime.load_settings('Breadcrumbs.sublime-settings')
+    separator = settings.get('breadcrumbs_separator', u' › ')
     phantoms = []
 
     for region in self.view.sel():
@@ -283,6 +288,7 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
 
       body = template.format(
           breadcrumbs=''.join(crumb_elements),
+          breadcrumbs_string=html.escape(separator.join(make_breadcrumbs(self.view, row, False)), quote=True),
           stylesheet=stylesheet
       )
       phantom = sublime.Phantom(

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -40,7 +40,7 @@ def get_breadcrumb(view, points, limit):
   return ''
 
 class BreadcrumbsCommand(sublime_plugin.EventListener):
-  def on_selection_modified(self, view):
+  def on_selection_modified_async(self, view):
     tab_size = get_tab_size(view)
     settings = sublime.load_settings('Breadcrumbs.sublime-settings')
     breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -58,8 +58,6 @@ def make_breadcrumbs(view, shorten):
   breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)
   total_breadcrumbs_length_limit = settings.get('total_breadcrumbs_length_limit', 200)
 
-  view.erase_status('breadcrumbs')
-
   if len(view.sel()) == 0:
     return
 
@@ -138,6 +136,7 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
 
   def on_selection_modified(self, view):
     settings = sublime.load_settings('Breadcrumbs.sublime-settings')
+    view.erase_status('breadcrumbs')
     if settings.get('breadcrumbs_statusbar', True):
       separator = settings.get('breadcrumbs_separator', u' › ')
       view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view, True)))

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -50,7 +50,7 @@ def get_breadcrumb(view, points, regex, limit):
   return ''
 
 
-def make_breadcrumbs(view):
+def make_breadcrumbs(view, shorten):
   settings = sublime.load_settings('Breadcrumbs.sublime-settings')
   tab_size = get_tab_size(view)
   breadcrumb_regex = settings.get('breadcrumb_regex', u'^\s*(?P<name>.*\\S)')
@@ -99,29 +99,31 @@ def make_breadcrumbs(view):
     current_row -= 1
 
   breadcrumbs.reverse()
-  lengths = [len(breadcrumb) for breadcrumb in breadcrumbs]
-  sorted_lengths = sorted(lengths)
-  previous_length = 0
-  number_of_characters_left = total_breadcrumbs_length_limit - len(lengths) * len(separator)
-  for (number_of_shorter, current_length) in enumerate(sorted_lengths):
-    if previous_length < current_length:
-      previous_length = current_length
-      number_of_not_shorter = len(breadcrumbs) - number_of_shorter
-      if number_of_characters_left < current_length * number_of_not_shorter:
-        length_of_short_trim = number_of_characters_left // number_of_not_shorter
-        length_of_long_trim = length_of_short_trim + 1
-        number_of_long_trimmed = number_of_characters_left % number_of_not_shorter
-        number_of_short_trimmed = number_of_not_shorter - number_of_long_trimmed
-        for (index_of_breadcrumb, breadcrum_length) in enumerate(lengths):
-          if current_length <= breadcrum_length:
-            if 0 < number_of_short_trimmed:
-              length_of_trim = length_of_short_trim
-              number_of_short_trimmed -= 1
-            else:
-              length_of_trim = length_of_long_trim
-            breadcrumbs[index_of_breadcrumb] = breadcrumbs[index_of_breadcrumb][0:length_of_trim]
-        break
-    number_of_characters_left -= current_length
+
+  if shorten:
+    lengths = [len(breadcrumb) for breadcrumb in breadcrumbs]
+    sorted_lengths = sorted(lengths)
+    previous_length = 0
+    number_of_characters_left = total_breadcrumbs_length_limit - len(lengths) * len(separator)
+    for (number_of_shorter, current_length) in enumerate(sorted_lengths):
+      if previous_length < current_length:
+        previous_length = current_length
+        number_of_not_shorter = len(breadcrumbs) - number_of_shorter
+        if number_of_characters_left < current_length * number_of_not_shorter:
+          length_of_short_trim = number_of_characters_left // number_of_not_shorter
+          length_of_long_trim = length_of_short_trim + 1
+          number_of_long_trimmed = number_of_characters_left % number_of_not_shorter
+          number_of_short_trimmed = number_of_not_shorter - number_of_long_trimmed
+          for (index_of_breadcrumb, breadcrum_length) in enumerate(lengths):
+            if current_length <= breadcrum_length:
+              if 0 < number_of_short_trimmed:
+                length_of_trim = length_of_short_trim
+                number_of_short_trimmed -= 1
+              else:
+                length_of_trim = length_of_long_trim
+              breadcrumbs[index_of_breadcrumb] = breadcrumbs[index_of_breadcrumb][0:length_of_trim]
+          break
+      number_of_characters_left -= current_length
 
   return breadcrumbs
 
@@ -138,7 +140,7 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
     settings = sublime.load_settings('Breadcrumbs.sublime-settings')
     if settings.get('breadcrumbs_statusbar', True):
       separator = settings.get('breadcrumbs_separator', u' › ')
-      view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view)))
+      view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view, True)))
     else:
       view.erase_status('breadcrumbs')
 
@@ -164,7 +166,7 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
       </body>
     '''
 
-    breadcrumbs = make_breadcrumbs(self.view)
+    breadcrumbs = make_breadcrumbs(self.view, False)
     settings = sublime.load_settings('Breadcrumbs.sublime-settings')
     separator = settings.get('breadcrumbs_separator', u' › ')
     if len(breadcrumbs) > 0:
@@ -256,7 +258,7 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
       (row, col) = self.view.rowcol(region.begin())
 
       crumb_elements = []
-      for crumb in make_breadcrumbs(self.view):
+      for crumb in make_breadcrumbs(self.view, False):
         crumb_elements.append('<span class="crumb">' + html.escape(crumb, quote=False) + '</span>')
 
       body = template.format(

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
 import html
-import time
 
 import sublime
 import sublime_plugin
@@ -15,10 +14,11 @@ except NameError:
 def get_tab_size(view):
   return int(view.settings().get('tab_size', 8))
 
-def get_row_indentation(line_start, view, tab_size, indentation_limit = None):
+
+def get_row_indentation(line_start, view, tab_size, indentation_limit=None):
   if indentation_limit is None:
     row = view.rowcol(line_start)[0]
-    indentation_limit = view.text_point(row +1, 0) - line_start
+    indentation_limit = view.text_point(row + 1, 0) - line_start
 
   pos = 0
   for ch in view.substr(sublime.Region(line_start, line_start + indentation_limit)):
@@ -35,6 +35,7 @@ def get_row_indentation(line_start, view, tab_size, indentation_limit = None):
       break
 
   return pos
+
 
 def is_white_row(view, points):
   return all(view.substr(pt).isspace() for pt in reversed(points))
@@ -60,6 +61,7 @@ def make_breadcrumbs(view, current_row, shorten=False):
   separator = settings.get('breadcrumbs_separator', u' › ')
   breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)
   total_breadcrumbs_length_limit = settings.get('total_breadcrumbs_length_limit', 200)
+
   def get_row_start(row):
     return view.text_point(row, 0)
 
@@ -208,13 +210,13 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
 
   def navigate(self, href, breadcrumbs_string):
     if href == 'close':
-      self.close();
+      self.close()
     else:
       copy(self.view, breadcrumbs_string)
 
   def run(self, edit):
     if self.phantoms_visible:
-      self.close();
+      self.close()
       return
 
     stylesheet = '''
@@ -283,7 +285,7 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
       (row, col) = self.view.rowcol(region.begin())
 
       crumb_elements = []
-      breadcrumbs = make_breadcrumbs(self.view, row);
+      breadcrumbs = make_breadcrumbs(self.view, row)
       for i, crumb in enumerate(breadcrumbs):
         parity = (i % 2) + 1
         crumb_elements.append('<span class="separator separator-{parity}"> </span><span class="crumb crumb-{parity}">'.format(parity=parity) + html.escape(crumb, quote=False) + '</span>')
@@ -297,7 +299,6 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
           region,
           body,
           sublime.LAYOUT_BLOCK,
-          # see: https://stackoverflow.com/questions/10452770/python-lambdas-binding-to-local-values
           on_navigate=lambda href, breadcrumbs_string=breadcrumbs_string: self.navigate(href, breadcrumbs_string)
       )
       phantoms.append(phantom)

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -188,13 +188,21 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
 class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
 
   def __init__(self, view):
+    self.phantoms_visible = False
     self.view = view
     self.phantom_set = sublime.PhantomSet(view, 'breadcrumbs')
 
-  def on_phantom_close(self, href):
+  def close_phantoms(self, href):
     self.view.erase_phantoms('breadcrumbs')
+    self.phantoms_visible = False
 
   def run(self, edit):
+    if self.phantoms_visible:
+      self.close_phantoms('close')
+      return
+    else:
+      self.close_phantoms('close')
+
     stylesheet = '''
       <style>
         html {
@@ -247,7 +255,6 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     '''
 
     phantoms = []
-    self.view.erase_phantoms('breadcrumbs')
 
     for region in self.view.sel():
       (row, col) = self.view.rowcol(region.begin())
@@ -264,10 +271,12 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
           region,
           body,
           sublime.LAYOUT_BELOW,
-          self.on_phantom_close
+          self.close_phantoms
       )
       phantoms.append(phantom)
+
     self.phantom_set.update(phantoms)
+    self.phantoms_visible = True
 
   def is_visible(self):
     return int(sublime.version()) > 3124

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -160,7 +160,7 @@ else:
 
     @classmethod
     def is_applicable(cls, settings):
-      return get_statusbar_enabled(settings) and viewevents_available
+      return get_statusbar_enabled(settings)
 
     def __init__(self, view):
       self.view = view

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -46,7 +46,7 @@ def get_breadcrumb(view, points, regex, limit):
     ch = view.substr(pt)
     if not ch.isspace():
       linestring = view.substr(sublime.Region(pt, min(view.line(pt).b, pt + limit))).strip()
-      match = re.search(re.compile(regex), linestring)
+      match = re.search(regex, linestring)
       if match:
         return(match.group('name'))
   return ''

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -10,8 +10,6 @@ try:
 except NameError:
   xrange = range
 
-settings = sublime.load_settings('Breadcrumbs.sublime-settings')
-
 
 def get_tab_size(view):
   return int(view.settings().get('tab_size', 8))
@@ -52,7 +50,8 @@ def get_breadcrumb(view, points, regex, limit):
   return ''
 
 
-def make_breadcrumbs(view):             
+def make_breadcrumbs(view):
+  settings = sublime.load_settings('Breadcrumbs.sublime-settings')
   tab_size = get_tab_size(view)
   breadcrumb_regex = settings.get('breadcrumb_regex', u'^\s*(?P<name>.*\\S)')
   separator = settings.get('breadcrumbs_separator', u' › ')
@@ -181,6 +180,7 @@ template = '''
 class BreadcrumbsCommand(sublime_plugin.EventListener):
 
   def on_selection_modified_async(self, view):
+    settings = sublime.load_settings('Breadcrumbs.sublime-settings')
     if settings.get('breadcrumbs_statusbar', True):
       view.set_status('breadcrumbs', make_breadcrumbs(view))
     else:

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -54,7 +54,7 @@ def get_breadcrumb(view, points, regex, limit):
 
 def make_breadcrumbs(view):
   tab_size = get_tab_size(view)
-  my_regex = settings.get('breadcrumbs_regex', u'(?P<name>.*)')
+  breadcrumb_regex = settings.get('breadcrumb_regex', u'(?P<name>.*)')
   separator = settings.get('breadcrumbs_separator', u' › ')
   breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)
   total_breadcrumbs_length_limit = settings.get('total_breadcrumbs_length_limit', 200)
@@ -93,7 +93,7 @@ def make_breadcrumbs(view):
     current_indentation = get_row_indentation(points, view, tab_size, indentation)
     if current_indentation < indentation and not is_white_row(view, points):
       indentation = current_indentation
-      this_breadcrumb = get_breadcrumb(view, points, my_regex, breadcrumb_length_limit)
+      this_breadcrumb = get_breadcrumb(view, points, breadcrumb_regex, breadcrumb_length_limit)
       if not this_breadcrumb == '':
         breadcrumbs.append(this_breadcrumb)
 

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -140,7 +140,7 @@ stylesheet = '''
     }
     div.phantom {
       margin: 0 0 0.2rem;
-      padding: 0.4rem 0;
+      padding: 0.4rem 0 0.4rem 0.7rem;
       border-radius: 0 0.2rem 0.2rem 0.2rem;
       background-color: var(--base-bg);
     }
@@ -149,16 +149,37 @@ stylesheet = '''
     }
     div.phantom strong {
       color:color(var(--base-bg) blend(var(--foreground) 30%));
-      padding: 0.4rem 0 0.4rem 0.7rem;
     }
-    div.phantom .crumb {
-      padding: 0.4rem 0.7rem 0.4rem 0.7rem;
-      border-right: 1px solid var(--accent-bg);
+    .crumb-1, .separator-1 {
+      background-color: var(--accent-bg);
+    }
+    .crumb-2, .separator-2 {
+      background-color: var(--base-bg);
+    }
+    .crumb-1,.crumb-2 {
+      line-height: 2rem;
+    }
+    .crumb-1,.crumb-2,.separator-1,.separator-2 {
+      display: inline-block;
+      vertical-align: middle;
+    }
+    .separator-1,.separator-2 {
+      border: 1rem solid;
+      width:0;
+      height:0;
+      font-size:1rem;
+      line-height:0px;
+    }
+    .separator-2 {
+      border-color: var(--base-bg);
+      border-left-color: var(--accent-bg);
+    }
+    .separator-1 {
+      border-color: var(--accent-bg);
+      border-left-color: var(--base-bg);
     }
     div.phantom a.close {
       padding: 0.35rem 0.7rem 0.45rem 0.8rem;
-      position: relative;
-      bottom: 0.05rem;
       border-radius: 0 0.2rem 0.2rem 0;
       font-weight: bold;
     }
@@ -176,9 +197,7 @@ template = '''
   <body id="inline-breadcrumbs">
     {stylesheet}
     <div class="phantom-arrow"></div>
-    <div class="phantom">
-      <strong>Breadcrumbs:</strong><span>{breadcrumbs}</span><a class="close" href="close">''' + chr(0x00D7) + '''</a>
-    </div>
+    <div class="phantom"><strong>Breadcrumbs:</strong>{breadcrumbs}<a class="close" href="close">''' + chr(0x00D7) + '''</a></div>
   </body>
 '''
 
@@ -212,8 +231,9 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
       (row, col) = self.view.rowcol(region.begin())
 
       crumb_elements = []
-      for crumb in make_breadcrumbs(self.view):
-        crumb_elements.append('<span class="crumb">' + html.escape(crumb, quote=False) + '</span>')
+      for i,crumb in enumerate(make_breadcrumbs(self.view)):
+        parity = (i % 2) + 1
+        crumb_elements.append('<span class="separator-{parity}"> </span><span class="crumb-{parity}">'.format(parity = parity) + html.escape(crumb, quote=False) + '</span>')
 
       body = template.format(
           breadcrumbs=''.join(crumb_elements),

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -205,7 +205,6 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     self.strings = {}
 
   def navigate(self, href):
-    print(self.strings)
     if href == 'close':
       self.view.erase_phantoms('breadcrumbs')
       self.phantoms_visible = False

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -136,7 +136,7 @@ def copy(view, text):
 
 class BreadcrumbsCommand(sublime_plugin.EventListener):
 
-  def on_selection_modified_async(self, view):
+  def on_selection_modified(self, view):
     settings = sublime.load_settings('Breadcrumbs.sublime-settings')
     if settings.get('breadcrumbs_statusbar', True):
       separator = settings.get('breadcrumbs_separator', u' › ')

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -45,7 +45,7 @@ def get_breadcrumb(view, points, regex, limit):
   for pt in points:
     ch = view.substr(pt)
     if not ch.isspace():
-      linestring = view.substr(sublime.Region(pt, min(view.line(pt).b, pt + limit))).strip()
+      linestring = view.substr(sublime.Region(pt, min(view.line(pt).b, pt + limit))).rstrip()
       match = re.search(regex, linestring)
       if match:
         return(match.group('name'))
@@ -54,7 +54,7 @@ def get_breadcrumb(view, points, regex, limit):
 
 def make_breadcrumbs(view):
   tab_size = get_tab_size(view)
-  breadcrumb_regex = settings.get('breadcrumb_regex', u'(?P<name>.*)')
+  breadcrumb_regex = settings.get('breadcrumb_regex', u'^\s*(?P<name>.*)')
   separator = settings.get('breadcrumbs_separator', u' › ')
   breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)
   total_breadcrumbs_length_limit = settings.get('total_breadcrumbs_length_limit', 200)

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -184,22 +184,23 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
 class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
 
   def __init__(self, view):
-      self.view = view
-      self.phantom_set = sublime.PhantomSet(view, 'breadcrumbs')
+    self.view = view
+    self.phantom_set = sublime.PhantomSet(view, 'breadcrumbs')
 
   def on_phantom_close(self, href):
-     self.view.erase_phantoms('breadcrumbs')
+    self.view.erase_phantoms('breadcrumbs')
 
   def run(self, edit):
-      phantoms = []
-      self.view.erase_phantoms('breadcrumbs')
+    phantoms = []
+    self.view.erase_phantoms('breadcrumbs')
 
-      for region in self.view.sel():
-          line = self.view.line(region)
-          (row, col) = self.view.rowcol(region.begin())
-          body = template.format(breadcrumbs=html.escape(make_breadcrumbs(self.view), quote=False), stylesheet=stylesheet)
-          phantom = sublime.Phantom(line, body, sublime.LAYOUT_BLOCK, self.on_phantom_close)
-          phantoms.append(phantom)
-      self.phantom_set.update(phantoms)
+    for region in self.view.sel():
+      line = self.view.line(region)
+      (row, col) = self.view.rowcol(region.begin())
+      body = template.format(breadcrumbs=html.escape(make_breadcrumbs(self.view), quote=False), stylesheet=stylesheet)
+      phantom = sublime.Phantom(line, body, sublime.LAYOUT_BLOCK, self.on_phantom_close)
+      phantoms.append(phantom)
+    self.phantom_set.update(phantoms)
+
   def is_visible(self):
     return int(sublime.version()) > 3124

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -44,7 +44,7 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
     tab_size = get_tab_size(view)
     settings = sublime.load_settings('Breadcrumbs.sublime-settings')
     breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)
-    separator = settings.get('breadcrumbs_separator', u' ■ ')
+    separator = settings.get('breadcrumbs_separator', u' › ')
     total_breadcrumbs_length_limit = settings.get('total_breadcrumbs_length_limit', 200)
     view.erase_status('breadcrumbs')
 

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 import re
+import sublime
+import sublime_plugin
 
 if int(sublime.version()) > 3124:
   import html
-
-import sublime
-import sublime_plugin
 
 try:
   xrange
@@ -181,7 +180,6 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
       </body>
     '''
 
-    settings = sublime.load_settings('Breadcrumbs.sublime-settings')
     view = self.view
     current_row = view.rowcol(view.sel()[0].b)[0]
     breadcrumbs = make_breadcrumbs(view, current_row)
@@ -202,8 +200,8 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
         body,
         max_width=512,
         on_navigate=lambda x: [
-          copy(view, breadcrumbs_string),
-          view.hide_popup()
+            copy(view, breadcrumbs_string),
+            view.hide_popup()
         ]
     )
 

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -166,7 +166,7 @@ else:
       self.view = view
 
       def clear():
-        if get_statusbar_enabled(view.settings()) is not True:
+        if not get_statusbar_enabled(view.settings()):
           view.erase_status('breadcrumbs')
 
       defaults = sublime.load_settings('Breadcrumbs.sublime-settings')

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -138,7 +138,11 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
     if settings.get('breadcrumbs_statusbar', True):
       separator = settings.get('breadcrumbs_separator', u' › ')
       current_row = view.rowcol(view.sel()[0].b)[0]
-      view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view, current_row, True)))
+      breadcrumbs = make_breadcrumbs(view, current_row, False)
+      if breadcrumbs is None or len(breadcrumbs) < 1:
+        view.erase_status('breadcrumbs')
+      else:
+        view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view, current_row, True)))
     else:
       view.erase_status('breadcrumbs')
 

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -171,8 +171,11 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
     view = self.view
     current_row = view.rowcol(view.sel()[0].b)[0]
     breadcrumbs = make_breadcrumbs(view, current_row, False)
+    escaped_crumbs = []
     if len(breadcrumbs) > 0:
-      breadcrumbs_element = '<br>'.join(breadcrumbs + [''])
+      for crumb in breadcrumbs:
+        escaped_crumbs.append(html.escape(crumb))
+      breadcrumbs_element = '<br>'.join(escaped_crumbs)
     else:
       breadcrumbs_element = '<em>None</em>'
 

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -46,7 +46,6 @@ def get_breadcrumb(view, points, regex, separator, limit):
     ch = view.substr(pt)
     if not ch.isspace():
       linestring = view.substr(sublime.Region(pt, min(view.line(pt).b, pt + limit))).strip()
-      print(regex)
       match = re.search(re.compile(regex), linestring)
       if match:
         return(separator + match.group('name'))

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -272,7 +272,7 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     template = '''
       <body id="inline-breadcrumbs">
         {stylesheet}
-        <div class="phantom">{breadcrumbs}<a href="{href}">Copy</a><a class="close" href="close">''' + chr(0x00D7) + '''</a></div>
+        <div class="phantom">{breadcrumbs}<a href="copy">Copy</a><a class="close" href="close">''' + chr(0x00D7) + '''</a></div>
       </body>
     '''
 
@@ -283,7 +283,6 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     for region in self.view.sel():
       (row, col) = self.view.rowcol(region.begin())
 
-      id = str(row)
       crumb_elements = []
       breadcrumbs = make_breadcrumbs(self.view, row);
       for i, crumb in enumerate(breadcrumbs):
@@ -293,7 +292,6 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
       breadcrumbs_string = separator.join(breadcrumbs)
       body = template.format(
           breadcrumbs=''.join(crumb_elements),
-          href=id,
           stylesheet=stylesheet
       )
       phantom = sublime.Phantom(

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 import html
+import html.parser
 
 import sublime
 import sublime_plugin
@@ -124,7 +125,7 @@ def make_breadcrumbs(view, current_row, shorten):
 
 
 def copy(view, text):
-  sublime.set_clipboard(text)
+  sublime.set_clipboard(html.parser.HTMLParser().unescape(text))
   view.hide_popup()
   sublime.status_message('Breadcrumbs copied to clipboard')
 
@@ -164,7 +165,7 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
       <body id=show-scope>
           <style>{stylesheet}</style>
           <p>{breadcrumbs}</p>
-          <a href="copy">Copy</a>
+          <a href="{breadcrumbs_string}">Copy</a>
       </body>
     '''
 
@@ -181,12 +182,12 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
     else:
       breadcrumbs_element = '<em>None</em>'
 
-    breadcrumbs_string = separator.join(breadcrumbs)
     body = template.format(
         breadcrumbs=breadcrumbs_element,
+        breadcrumbs_string=html.escape(separator.join(breadcrumbs), quote=True),
         stylesheet=stylesheet
     )
-    view.show_popup(body, max_width=512, on_navigate=copy(view, breadcrumbs_string))
+    view.show_popup(body, max_width=512, on_navigate=lambda x: copy(view, x))
 
   def is_visible(self):
     return int(sublime.version()) > 3124

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -41,14 +41,14 @@ def is_white_row(view, points):
   return all(view.substr(pt).isspace() for pt in reversed(points))
 
 
-def get_breadcrumb(view, points, regex, separator, limit):
+def get_breadcrumb(view, points, regex, limit):
   for pt in points:
     ch = view.substr(pt)
     if not ch.isspace():
       linestring = view.substr(sublime.Region(pt, min(view.line(pt).b, pt + limit))).strip()
       match = re.search(re.compile(regex), linestring)
       if match:
-        return(separator + match.group('name'))
+        return(match.group('name'))
   return ''
 
 
@@ -93,7 +93,9 @@ def make_breadcrumbs(view):
     current_indentation = get_row_indentation(points, view, tab_size, indentation)
     if current_indentation < indentation and not is_white_row(view, points):
       indentation = current_indentation
-      breadcrumbs.append(get_breadcrumb(view, points, my_regex, separator, breadcrumb_length_limit))
+      this_breadcrumb = get_breadcrumb(view, points, my_regex, breadcrumb_length_limit)
+      if not this_breadcrumb == '':
+        breadcrumbs.append(this_breadcrumb)
 
     current_row -= 1
 
@@ -122,7 +124,7 @@ def make_breadcrumbs(view):
         break
     number_of_characters_left -= current_length
 
-  return ''.join(breadcrumbs + [''])
+  return separator.join(breadcrumbs + [''])
 
 
 stylesheet = '''

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -207,7 +207,7 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
       <style>
         html {
           --base-bg: color(var(--bluish) blend(var(--background) 30%));
-          --accent-bg: color(var(--base-bg) blend(var(--foreground) 60%));
+          --accent-bg: color(var(--base-bg) blend(var(--foreground) 90%));
         }
         div.phantom-arrow {
           border-top: 0.4rem solid transparent;
@@ -217,54 +217,45 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
         }
         div.phantom {
           margin: 0 0 0.2rem;
-          padding: 0.4rem 0 0.4rem 0.7rem;
           border-radius: 0 0.2rem 0.2rem 0.2rem;
-          background-color: var(--base-bg);
         }
         div.phantom a {
           text-decoration: inherit;
         }
-        div.phantom strong {
-          color:color(var(--base-bg) blend(var(--foreground) 30%));
-        }
-        .crumb-1, .separator-1 {
-          background-color: var(--accent-bg);
-        }
-        .crumb-2, .separator-2 {
-          background-color: var(--base-bg);
-        }
-        .crumb-1,.crumb-2 {
+       .crumb {
           line-height: 2rem;
+          padding-right: 1rem;
         }
-        .crumb-1,.crumb-2,.separator-1,.separator-2 {
-          display: inline-block;
-          vertical-align: middle;
-        }
-        .separator-1,.separator-2 {
+        .separator {
           border: 1rem solid;
           width:0;
           height:0;
           font-size:1rem;
           line-height:0px;
         }
+        .crumb-1,
+        .separator-1 {
+          background-color: var(--base-bg);
+        }
+        .crumb-2,
         .separator-2 {
+          background-color: var(--accent-bg);
+        }
+        .separator-1 {
           border-color: var(--base-bg);
           border-left-color: var(--accent-bg);
         }
-        .separator-1 {
+        .separator-2 {
           border-color: var(--accent-bg);
           border-left-color: var(--base-bg);
         }
         div.phantom a.close {
-          padding: 0.35rem 0.7rem 0.45rem 0.8rem;
+          vertical-align: middle;
+          line-height: 2rem;
+          padding: 0 0.7rem 0 0.8rem;
           border-radius: 0 0.2rem 0.2rem 0;
           font-weight: bold;
-        }
-        html.dark div.phantom a.close {
-          background-color: #00000018;
-        }
-        html.light div.phantom a.close {
-          background-color: #ffffff18;
+          background-color: var(--base-bg);
         }
       </style>
     '''
@@ -273,7 +264,7 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
       <body id="inline-breadcrumbs">
         {stylesheet}
         <div class="phantom-arrow"></div>
-        <div class="phantom"><strong>Breadcrumbs:</strong>{breadcrumbs}<a class="close" href="close">''' + chr(0x00D7) + '''</a></div>
+        <div class="phantom">{breadcrumbs}<a class="close" href="close">''' + chr(0x00D7) + '''</a></div>
       </body>
     '''
 
@@ -285,7 +276,7 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
       crumb_elements = []
       for i,crumb in enumerate(make_breadcrumbs(self.view, row, False)):
         parity = (i % 2) + 1
-        crumb_elements.append('<span class="separator-{parity}"> </span><span class="crumb-{parity}">'.format(parity = parity) + html.escape(crumb, quote=False) + '</span>')
+        crumb_elements.append('<span class="separator separator-{parity}"> </span><span class="crumb crumb-{parity}">'.format(parity = parity) + html.escape(crumb, quote=False) + '</span>')
 
       body = template.format(
           breadcrumbs=''.join(crumb_elements),

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -216,10 +216,6 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
         div.phantom a {
           text-decoration: inherit;
         }
-        div.phantom strong {
-          color:color(var(--base-bg) blend(var(--foreground) 30%));
-          padding: 0.4rem 0 0.4rem 0.7rem;
-        }
         div.phantom .crumb {
           padding: 0.4rem 0.7rem 0.4rem 0.7rem;
           border-right: 1px solid var(--accent-bg);
@@ -245,7 +241,7 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
         {stylesheet}
         <div class="phantom-arrow"></div>
         <div class="phantom">
-          <strong>Breadcrumbs:</strong><span>{breadcrumbs}</span><a class="close" href="close">''' + chr(0x00D7) + '''</a>
+          <span>{breadcrumbs}</span><a class="close" href="close">''' + chr(0x00D7) + '''</a>
         </div>
       </body>
     '''
@@ -255,7 +251,6 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     view.erase_phantoms('breadcrumbs')
 
     for region in view.sel():
-      line = view.line(region)
       (row, col) = view.rowcol(region.begin())
 
       crumb_elements = []
@@ -266,7 +261,12 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
           breadcrumbs=''.join(crumb_elements),
           stylesheet=stylesheet
       )
-      phantom = sublime.Phantom(line, body, sublime.LAYOUT_BLOCK, self.on_phantom_close)
+      phantom = sublime.Phantom(
+          region,
+          body,
+          sublime.LAYOUT_BELOW,
+          self.on_phantom_close
+      )
       phantoms.append(phantom)
     self.phantom_set.update(phantoms)
 

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import re
-import html
+
+if int(sublime.version()) > 3124:
+  import html
 
 import sublime
 import sublime_plugin
@@ -48,18 +50,18 @@ def get_separator(view):
   return separator
 
 
-def get_breadcrumb(view, points, regex, limit):
-  linestring = view.substr(sublime.Region(min(points), min(view.line(min(points)).b, min(points) + limit)))
+def get_breadcrumb(view, line_start, line_end, regex, limit):
+  linestring = view.substr(sublime.Region(line_start, min(line_end, line_start + 1024)))
   match = re.search(regex, linestring)
   if match:
-    return(match.group('name'))
+    return match.group('name')[0:limit]
   else:
     return None
 
 
 def make_breadcrumbs(view, current_row, shorten=False):
   if len(view.sel()) == 0:
-    return
+    return []
 
   settings = sublime.load_settings('Breadcrumbs.sublime-settings')
   tab_size = get_tab_size(view)
@@ -80,7 +82,7 @@ def make_breadcrumbs(view, current_row, shorten=False):
       current_row -= 1
 
     if current_row < 0:
-      return
+      return []
 
     indentation = get_row_indentation(get_row_start(current_row), view, tab_size) + 1
   else:
@@ -91,25 +93,24 @@ def make_breadcrumbs(view, current_row, shorten=False):
   last_line_start = view.text_point(current_row + 1, 0)
   while 0 <= current_row and 0 < indentation:
     line_start = get_row_start(current_row)
-    points = xrange(line_start, last_line_start)
+    line_end = last_line_start
     last_line_start = line_start
     current_indentation = get_row_indentation(line_start, view, tab_size, indentation)
-    if current_indentation < indentation and not is_white_row(view, points):
+    if current_indentation < indentation and not is_white_row(view, xrange(line_start, line_end)):
       indentation = current_indentation
-      this_breadcrumb = get_breadcrumb(view, points, breadcrumb_regex, breadcrumb_length_limit)
+      this_breadcrumb = get_breadcrumb(view, line_start, line_end, breadcrumb_regex, breadcrumb_length_limit)
       if this_breadcrumb is not None:
         breadcrumbs.append(this_breadcrumb)
 
     current_row -= 1
 
   breadcrumbs.reverse()
-
   if shorten:
     total_breadcrumbs_length_limit = settings.get('total_breadcrumbs_length_limit', 200)
     lengths = [len(breadcrumb) for breadcrumb in breadcrumbs]
     sorted_lengths = sorted(lengths)
     previous_length = 0
-    number_of_characters_left = total_breadcrumbs_length_limit - len(lengths) * len(get_separator(view))
+    number_of_characters_left = max(0, total_breadcrumbs_length_limit - len(lengths) * len(get_separator(view)))
     for (number_of_shorter, current_length) in enumerate(sorted_lengths):
       if previous_length < current_length:
         previous_length = current_length
@@ -134,7 +135,6 @@ def make_breadcrumbs(view, current_row, shorten=False):
 
 def copy(view, text):
   sublime.set_clipboard(text)
-  view.hide_popup()
   sublime.status_message('Breadcrumbs copied to clipboard')
 
 
@@ -151,7 +151,7 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
       current_row = view.rowcol(view.sel()[0].b)[0]
       breadcrumbs = make_breadcrumbs(view, current_row, shorten=True)
 
-      if breadcrumbs is not None and len(breadcrumbs) > 0:
+      if len(breadcrumbs) > 0:
         view.set_status('breadcrumbs', get_separator(view).join(breadcrumbs))
 
 
@@ -163,7 +163,6 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
         margin-top: 0;
       }
       a {
-        font-family: system;
         font-size: 1.05rem;
       }
     '''
@@ -196,7 +195,10 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
     view.show_popup(
         body,
         max_width=512,
-        on_navigate=lambda x: copy(view, breadcrumbs_string)
+        on_navigate=lambda x: [
+          copy(view, breadcrumbs_string),
+          view.hide_popup()
+        ]
     )
 
   def is_visible(self):

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 import html
+import html.parser
 
 import sublime
 import sublime_plugin

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -48,10 +48,15 @@ def is_white_row(view, points):
 
 
 def get_separator(view):
-  settings = sublime.load_settings('Breadcrumbs.sublime-settings')
-  default_separator = settings.get('breadcrumbs_separator', u' ')
-  separator = view.settings().get('breadcrumbs_separator', default_separator)
-  return separator
+  defaults = sublime.load_settings('Breadcrumbs.sublime-settings')
+  default_separator = defaults.get('breadcrumbs_separator', u' ')
+  return view.settings().get('breadcrumbs_separator', default_separator)
+
+
+def get_statusbar_enabled(settings):
+  defaults = sublime.load_settings('Breadcrumbs.sublime-settings')
+  default_enabled = defaults.get('show_breadcrumbs_in_statusbar', True)
+  return settings.get('show_breadcrumbs_in_statusbar', default_enabled)
 
 
 def get_breadcrumb(view, line_start, line_end, regex, limit):
@@ -146,11 +151,7 @@ if viewevents_available is not True:
   class BreadcrumbsEventListenerST2(sublime_plugin.EventListener):
 
     def on_selection_modified(self, view):
-      settings = sublime.load_settings('Breadcrumbs.sublime-settings')
-      default_statusbar_enabled = settings.get('show_breadcrumbs_in_statusbar', True)
-      statusbar_enabled = view.settings().get('show_breadcrumbs_in_statusbar', default_statusbar_enabled)
-
-      if statusbar_enabled:
+      if get_statusbar_enabled(view.settings()):
         current_row = view.rowcol(view.sel()[0].b)[0]
         breadcrumbs = make_breadcrumbs(view, current_row, shorten=True)
 
@@ -164,21 +165,16 @@ class BreadcrumbsEventListenerST3(sublime_plugin.ViewEventListener):
 
   @classmethod
   def is_applicable(cls, settings):
-    defaults = sublime.load_settings('Breadcrumbs.sublime-settings')
-    default_enabled = defaults.get('show_breadcrumbs_in_statusbar', True)
-    enabled = settings.get('show_breadcrumbs_in_statusbar', default_enabled)
-    return enabled and viewevents_available
+    return get_statusbar_enabled(settings) and viewevents_available
 
   def __init__(self, view):
     self.view = view
-    defaults = sublime.load_settings('Breadcrumbs.sublime-settings')
 
     def clear():
-      default_enabled = defaults.get('show_breadcrumbs_in_statusbar', True)
-      enabled = view.settings().get('show_breadcrumbs_in_statusbar', default_enabled)
-      if enabled is not True:
+      if get_statusbar_enabled(view.settings()) is not True:
         view.erase_status('breadcrumbs')
 
+    defaults = sublime.load_settings('Breadcrumbs.sublime-settings')
     defaults.add_on_change('show_breadcrumbs_in_statusbar', clear)
     view.settings().add_on_change('show_breadcrumbs_in_statusbar', clear)
 

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -138,12 +138,8 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
       separator = settings.get('breadcrumbs_separator', u' › ')
       current_row = view.rowcol(view.sel()[0].b)[0]
       breadcrumbs = make_breadcrumbs(view, current_row, False)
-      if breadcrumbs is None or len(breadcrumbs) < 1:
-        view.erase_status('breadcrumbs')
-      else:
+      if breadcrumbs is not None and len(breadcrumbs) > 0:
         view.set_status('breadcrumbs', separator.join(make_breadcrumbs(view, current_row, True)))
-    else:
-      view.erase_status('breadcrumbs')
 
 
 class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -201,3 +201,5 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
           phantom = sublime.Phantom(line, body, sublime.LAYOUT_BLOCK, self.on_phantom_close)
           phantoms.append(phantom)
       self.phantom_set.update(phantoms)
+  def is_visible(self):
+    return int(sublime.version()) > 3124

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
 import html
-import html.parser
 
 import sublime
 import sublime_plugin
@@ -125,7 +124,7 @@ def make_breadcrumbs(view, current_row, shorten):
 
 
 def copy(view, text):
-  sublime.set_clipboard(html.parser.HTMLParser().unescape(text))
+  sublime.set_clipboard(text)
   view.hide_popup()
   sublime.status_message('Breadcrumbs copied to clipboard')
 
@@ -165,7 +164,7 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
       <body id=show-scope>
           <style>{stylesheet}</style>
           <p>{breadcrumbs}</p>
-          <a href="{breadcrumbs_string}">Copy</a>
+          <a href="copy">Copy</a>
       </body>
     '''
 
@@ -182,12 +181,12 @@ class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):
     else:
       breadcrumbs_element = '<em>None</em>'
 
+    breadcrumbs_string = separator.join(breadcrumbs)
     body = template.format(
         breadcrumbs=breadcrumbs_element,
-        breadcrumbs_string=html.escape(separator.join(breadcrumbs), quote=True),
         stylesheet=stylesheet
     )
-    view.show_popup(body, max_width=512, on_navigate=lambda x: copy(view, x))
+    view.show_popup(body, max_width=512, on_navigate=copy(view, breadcrumbs_string))
 
   def is_visible(self):
     return int(sublime.version()) > 3124

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -165,9 +165,7 @@ class BreadcrumbsEventListener(sublime_plugin.ViewEventListener):
   def on_selection_modified(self):
     current_row = self.view.rowcol(self.view.sel()[0].b)[0]
     breadcrumbs = make_breadcrumbs(self.view, current_row, shorten=True)
-
-    if len(breadcrumbs) > 0:
-      self.view.set_status('breadcrumbs', get_separator(self.view).join(breadcrumbs))
+    self.view.set_status('breadcrumbs', get_separator(self.view).join(breadcrumbs))
 
 
 class BreadcrumbsPopupCommand(sublime_plugin.TextCommand):

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -180,6 +180,7 @@ class BreadcrumbsCommand(sublime_plugin.EventListener):
     else:
       view.erase_status('breadcrumbs')
 
+
 class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
 
   def __init__(self, view):

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -45,16 +45,16 @@ def get_breadcrumb(view, points, regex, limit):
   for pt in points:
     ch = view.substr(pt)
     if not ch.isspace():
-      linestring = view.substr(sublime.Region(pt, min(view.line(pt).b, pt + limit))).rstrip()
+      linestring = view.substr(sublime.Region(pt, min(view.line(pt).b, pt + limit)))
       match = re.search(regex, linestring)
       if match:
         return(match.group('name'))
   return ''
 
 
-def make_breadcrumbs(view):
+def make_breadcrumbs(view):             
   tab_size = get_tab_size(view)
-  breadcrumb_regex = settings.get('breadcrumb_regex', u'^\s*(?P<name>.*)')
+  breadcrumb_regex = settings.get('breadcrumb_regex', u'^\s*(?P<name>.*\\S)')
   separator = settings.get('breadcrumbs_separator', u' › ')
   breadcrumb_length_limit = settings.get('breadcrumb_length_limit', 100)
   total_breadcrumbs_length_limit = settings.get('total_breadcrumbs_length_limit', 200)

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -247,14 +247,13 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     '''
 
     phantoms = []
-    view = self.view
-    view.erase_phantoms('breadcrumbs')
+    self.view.erase_phantoms('breadcrumbs')
 
-    for region in view.sel():
-      (row, col) = view.rowcol(region.begin())
+    for region in self.view.sel():
+      (row, col) = self.view.rowcol(region.begin())
 
       crumb_elements = []
-      for crumb in make_breadcrumbs(view, row, False):
+      for crumb in make_breadcrumbs(self.view, row, False):
         crumb_elements.append('<span class="crumb">' + html.escape(crumb, quote=False) + '</span>')
 
       body = template.format(

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -241,9 +241,13 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
         div.phantom {
           margin: 0;
         }
+        i,
         .crumb {
           line-height: 2em;
           padding-right: 6px;
+        }
+        i {
+          padding-left: 6px;
         }
         .separator {
           border: 1em solid;
@@ -252,8 +256,9 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
           font-size: inherit;
           line-height: 0px;
         }
-        .crumb-1,
-        .separator-1 {
+        i,
+        .crumb,
+        .separator {
           background-color: var(--base-bg);
         }
         .crumb-2,
@@ -296,13 +301,18 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
 
       crumb_elements = []
       breadcrumbs = make_breadcrumbs(self.view, row)
-      for i, crumb in enumerate(breadcrumbs):
-        parity = (i % 2) + 1
-        crumb_elements.append('<span class="separator separator-{parity}"> </span><span class="crumb crumb-{parity}">'.format(parity=parity) + html.escape(crumb, quote=False) + '</span>')
-
       breadcrumbs_string = get_separator(self.view).join(breadcrumbs)
+
+      if len(breadcrumbs) > 0:
+        for i, crumb in enumerate(breadcrumbs):
+          parity = (i % 2) + 1
+          crumb_elements.append('<span class="separator separator-{parity}"> </span><span class="crumb crumb-{parity}">'.format(parity=parity) + html.escape(crumb, quote=False) + '</span>')
+        breadcrumbs_element = ''.join(crumb_elements)
+      else:
+        breadcrumbs_element = '<i>None</i>'
+
       body = template.format(
-          breadcrumbs=''.join(crumb_elements),
+          breadcrumbs=breadcrumbs_element,
           stylesheet=stylesheet
       )
       phantom = sublime.Phantom(

--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -277,9 +277,9 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
       (row, col) = self.view.rowcol(region.begin())
 
       crumb_elements = []
-      for i,crumb in enumerate(make_breadcrumbs(self.view, row, False)):
+      for i, crumb in enumerate(make_breadcrumbs(self.view, row, False)):
         parity = (i % 2) + 1
-        crumb_elements.append('<span class="separator separator-{parity}"> </span><span class="crumb crumb-{parity}">'.format(parity = parity) + html.escape(crumb, quote=False) + '</span>')
+        crumb_elements.append('<span class="separator separator-{parity}"> </span><span class="crumb crumb-{parity}">'.format(parity=parity) + html.escape(crumb, quote=False) + '</span>')
 
       body = template.format(
           breadcrumbs=''.join(crumb_elements),

--- a/Breadcrumbs.sublime-commands
+++ b/Breadcrumbs.sublime-commands
@@ -1,0 +1,6 @@
+[
+  {
+    "caption": "Show Breadcrumbs",
+    "command": "breadcrumbs_phantom"
+  }
+]

--- a/Breadcrumbs.sublime-commands
+++ b/Breadcrumbs.sublime-commands
@@ -1,6 +1,6 @@
 [
   {
     "caption": "Show Breadcrumbs",
-    "command": "breadcrumbs_phantom"
+    "command": "breadcrumbs_popup"
   }
 ]

--- a/Breadcrumbs.sublime-commands
+++ b/Breadcrumbs.sublime-commands
@@ -2,5 +2,9 @@
   {
     "caption": "Show Breadcrumbs",
     "command": "breadcrumbs_popup"
+  },
+  {
+    "caption": "Show Breadcrumbs Inline",
+    "command": "breadcrumbs_phantom"
   }
 ]

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -1,6 +1,6 @@
 {
-	"breadcrumb_length_limit": 100,
-	"total_breadcrumbs_length_limit": 200,
-	"breadcrumbs_separator": " › ",
-	"breadcrumbs_regex": "(?P<name>.*)"
+  "breadcrumb_length_limit": 100,
+  "total_breadcrumbs_length_limit": 200,
+  "breadcrumbs_separator": " › ",
+  "breadcrumbs_regex": "(?P<name>.*)"
 }

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -1,6 +1,6 @@
 {
-  "breadcrumb_length_limit": 100,
-  "total_breadcrumbs_length_limit": 200,
+  "breadcrumb_length_limit": 50,
+  "total_breadcrumbs_length_limit": 50,
   "breadcrumbs_separator": " › ",
   "breadcrumb_regex": "^\\s*(?P<name>.*\\S)",
   "breadcrumbs_statusbar": true

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -2,6 +2,6 @@
   "breadcrumb_length_limit": 100,
   "total_breadcrumbs_length_limit": 200,
   "breadcrumbs_separator": " › ",
-  "breadcrumbs_regex": "(?P<name>.*)",
+  "breadcrumb_regex": "(?P<name>.*)",
   "breadcrumbs_statusbar": true
 }

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -1,6 +1,6 @@
 {
-  "breadcrumb_length_limit": 50,
-  "total_breadcrumbs_length_limit": 50,
+  "breadcrumb_length_limit": 100,
+  "total_breadcrumbs_length_limit": 200,
   "breadcrumbs_separator": " › ",
   "breadcrumb_regex": "^\\s*(?P<name>.*\\S)",
   "breadcrumbs_statusbar": true

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -1,5 +1,5 @@
 {
 "breadcrumb_length_limit": 100,
 "total_breadcrumbs_length_limit": 200,
-"breadcrumbs_separator": " ■ "
+	"breadcrumbs_separator": " › "
 }

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -1,5 +1,6 @@
 {
 	"breadcrumb_length_limit": 100,
 	"total_breadcrumbs_length_limit": 200,
-	"breadcrumbs_separator": " › "
+	"breadcrumbs_separator": " › ",
+	"breadcrumbs_regex": "(?P<name>.*)"
 }

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -1,5 +1,5 @@
 {
-"breadcrumb_length_limit": 100,
-"total_breadcrumbs_length_limit": 200,
+	"breadcrumb_length_limit": 100,
+	"total_breadcrumbs_length_limit": 200,
 	"breadcrumbs_separator": " › "
 }

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -2,6 +2,6 @@
   "breadcrumb_length_limit": 100,
   "total_breadcrumbs_length_limit": 200,
   "breadcrumbs_separator": " › ",
-  "breadcrumb_regex": "^\\s*(?P<name>.*)",
+  "breadcrumb_regex": "^\\s*(?P<name>.*\\S)",
   "breadcrumbs_statusbar": true
 }

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -2,5 +2,6 @@
   "breadcrumb_length_limit": 100,
   "total_breadcrumbs_length_limit": 200,
   "breadcrumbs_separator": " › ",
-  "breadcrumbs_regex": "(?P<name>.*)"
+  "breadcrumbs_regex": "(?P<name>.*)",
+  "breadcrumbs_statusbar": true
 }

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -1,7 +1,7 @@
 {
+  "breadcrumb_regex": "^\\s*(?P<name>.*\\S)",
   "breadcrumb_length_limit": 100,
   "total_breadcrumbs_length_limit": 200,
   "breadcrumbs_separator": " › ",
-  "breadcrumb_regex": "^\\s*(?P<name>.*\\S)",
-  "breadcrumbs_statusbar": true
+  "show_breadcrumbs_in_statusbar": true
 }

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -2,6 +2,6 @@
   "breadcrumb_length_limit": 100,
   "total_breadcrumbs_length_limit": 200,
   "breadcrumbs_separator": " › ",
-  "breadcrumb_regex": "(?P<name>.*)",
+  "breadcrumb_regex": "^\\s*(?P<name>.*)",
   "breadcrumbs_statusbar": true
 }

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -1,7 +1,32 @@
 {
+  // Strips the full line that is used as breadcrumb down to the "name" group.
+  // This regex is intended to provide a useful crumb in most languages,
+  // but you can change thihs for each language you use.
+  // Read about Syntax Specific settings here:
+  // https://www.sublimetext.com/docs/3/settings.html
+  //
+  // Some examples:
+  // Python: "(?i)^\\s*(def|class)\\s*(?P<name>[a-z0-9-_ ]+)\\b"
+  // JSON: "^\\s*\"(?P<name>[^\"]+)\".*"
+  // Note that your regex should include one (?P<name>) group,
+  // this group is the only part that is used to create a crumb.
   "breadcrumb_regex": "^([{}\\(\\)\\[\\]\\s])*\\s*(?P<name>[^{\\(\\[]*[^:{\\(\\[\\s])",
-  "breadcrumb_length_limit": 100,
-  "total_breadcrumbs_length_limit": 200,
+
+  // The seperator used in between breadcrumbs in the statusbar.
+  // Also used when you copy breadcrumbs from the popup or the phantoms.
+  // This can also be changed per syntax.
+  // Some suggestions: ○ ● » ∕ ˙ · ♥
   "breadcrumbs_separator": " › ",
-  "show_breadcrumbs_in_statusbar": true
+
+  // Limit the length of each "crumb" to this many characters.
+  "breadcrumb_length_limit": 100,
+
+  // Choose if breadcrumbs will be shown in the statusbar.
+  // This can also be changed per syntax.
+  "show_breadcrumbs_in_statusbar": true,
+
+  // Limit the total length of the breadcrumbs to this many characters,
+  // by trimming the longest breadcrumbs first.
+  // Is only applied to the breadcrumbs visible in the statusbar.
+  "total_breadcrumbs_length_limit": 200
 }

--- a/Breadcrumbs.sublime-settings
+++ b/Breadcrumbs.sublime-settings
@@ -1,5 +1,5 @@
 {
-  "breadcrumb_regex": "^\\s*(?P<name>.*\\S)",
+  "breadcrumb_regex": "^([{}\\(\\)\\[\\]\\s])*\\s*(?P<name>[^{\\(\\[]*[^:{\\(\\[\\s])",
   "breadcrumb_length_limit": 100,
   "total_breadcrumbs_length_limit": 200,
   "breadcrumbs_separator": " › ",

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "breadcrumbs",
+    "caption": "Show Breadcrumbs",
+    "command": "breadcrumbs_phantom"
+  }
+]

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -2,6 +2,6 @@
   {
     "id": "breadcrumbs",
     "caption": "Show Breadcrumbs",
-    "command": "breadcrumbs_phantom"
+    "command": "breadcrumbs_popup"
   }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,31 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "Breadcrumbs",
+                        "children":
+                        [
+                            {
+                                "caption": "Settings",
+                                "command": "edit_settings",
+                                "args": {
+                                    "base_file": "${packages}/Breadcrumbs/Breadcrumbs.sublime-settings"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ You can edit Breadcrumbs.sublime-settings to specify the following values:
 
 To only show Python classes and methods use:  
 `"^\\s*(def|class)\\s+(?P<name>.+)\\(.*"`
+
+### Example keybindings
+
+This package doesn't provide keybindings for its commands, allowing you to customise them as you see fit. Here are some examples:
+
+```json
+{ "keys": ["super+ctrl+b"], "command": "breadcrumbs_popup" },
+{ "keys": ["super+ctrl+alt+b"], "command": "breadcrumbs_phantom" }
+```

--- a/README.md
+++ b/README.md
@@ -39,13 +39,18 @@ You can edit Breadcrumbs.sublime-settings to specify the following values:
 |"breadcrumb_length_limit" | Number | 100 | Trim each breadcrumb to this many characters |
 | "total_breadcrumbs_length_limit" | Number | 200 | Limit the total length of the breadcrumbs, by trimming the longest breadcrumbs first |
 | "breadcrumbs_separator" | String | " › " | Separate breadcrumbs using this string |
-| "breadcrumbs_regex" | String | "^\\s*(?P<name>.*\\S)" | Use only the part that matches the "name" group |
 | "breadcrumbs_statusbar" | Boolean | true | Optionally hide the breadcrumbs from the statusbar |
 
-### Example regexes
+### Tuning the breadcrumbs with regular expressions
 
-- For Python classes and methods: `"^\\s*(def|class)\\s+(?P<name>.+)\\(.*"`
-- For JSON: `"^\\s*\"(?P<name>[^\"]+)\".*"`
+This packages comes with a very basic regex (`"^\\s*(?P<name>.*\\S)"`) to clean up each breadcrumb. Only the part that matches the "name" group is used.
+
+You can create [Syntax Specific settings](https://www.sublimetext.com/docs/3/settings.html) to fine-tune it for each language you use. Some examples:
+
+- For Python  
+`"breadcrumb_regex": "(?i)^\\s*(def|class)\\s*(?P<name>[a-z0-9-_ ]+)\\b"`
+- For JSON  
+`"breadcrumb_regex": "^\\s*\"(?P<name>[^\"]+)\".*"`
 
 ### Example keybindings
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can edit Breadcrumbs.sublime-settings to specify the following values:
 |"breadcrumb_length_limit" | Number | 100 | Trim each line to this many characters to form a breadcrumb |
 | "total_breadcrumbs_length_limit" | Number | 200 | Make sure that the total length of the status is no longer than this many characters, by trimming the longest breadcrumbs first |
 | "breadcrumbs_separator" | String | " › " | Separate breadcrumbs using this character |
-| "breadcrumbs_regex" | String | "(?P<name>.*)" | Use only the part that matches the "name" group |
+| "breadcrumbs_regex" | String | "^\\s*(?P<name>.*)" | Use only the part that matches the "name" group |
 | "breadcrumbs_statusbar" | Boolean | true | Optionally disable hide the breadcrumbs from the statusbar |
 
 ### Example regexes

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can edit Breadcrumbs.sublime-settings to specify the following values:
 |"breadcrumb_length_limit" | Number | 100 | Trim each line to this many characters to form a breadcrumb |
 | "total_breadcrumbs_length_limit" | Number | 200 | Make sure that the total length of the status is no longer than this many characters, by trimming the longest breadcrumbs first |
 | "breadcrumbs_separator" | String | " › " | Separate breadcrumbs using this character |
-| "breadcrumbs_regex" | String | "^\\s*(?P<name>.*)" | Use only the part that matches the "name" group |
+| "breadcrumbs_regex" | String | "^\\s*(?P<name>.*\\S)" | Use only the part that matches the "name" group |
 | "breadcrumbs_statusbar" | Boolean | true | Optionally disable hide the breadcrumbs from the statusbar |
 
 ### Example regexes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Breadcrumbs
-A plugin to Sublime Text 2 and Sublime Text 3, which adds breadcrumbs to the status bar based on scopes the current line belongs to.
+A plugin to Sublime Text 2 and Sublime Text 3, which adds breadcrumbs to the status bar based on scopes the current line belongs to. Alternatively, the breadcrumbs can be displayed inline using the Show Breadcrumbs command.
 This is done based on indentation, by assuming that scopes are indented.
 
 For example if your code looks like this:
@@ -37,4 +37,6 @@ You can edit Breadcrumbs.sublime-settings to specify the following values:
 |------|------|---------|---------|
 |"breadcrumb_length_limit" | Number | 100 | Trim each line to this many characters to form a breadcrumb |
 | "total_breadcrumbs_length_limit" | Number | 200 | Make sure that the total length of the status is no longer than this many characters, by trimming the longest breadcrumbs first |
-| "breadcrumbs_separator" | String | " ■ " | Separate breadcrumbs using this character |
+| "breadcrumbs_separator" | String | " › " | Separate breadcrumbs using this character |
+| "breadcrumbs_regex" | String | "(?P<name>.*)" | Use only the part that matches the "name" group |
+| "breadcrumbs_statusbar" | Boolean | true | Optionally disable hide the breadcrumbs from the statusbar |

--- a/README.md
+++ b/README.md
@@ -1,33 +1,34 @@
 # Breadcrumbs
-A plugin to Sublime Text 2 and Sublime Text 3, which adds breadcrumbs to the status bar based on scopes the current line belongs to. Alternatively, the breadcrumbs can be displayed in a popup using the Show Breadcrumbs command.
-This is done based on indentation, by assuming that scopes are indented.
+A plugin for Sublime Text 2 and 3, which shows the breadcrumbs to your current caret position based on indentation.
+Breadcrumbs can be displayed in the statusbar, a popup (via Show Breadcrumbs) or in between the lines of your code (via Show Breadcrumbs Inline).
 
 For example if your code looks like this:
-```
+
+```javascript
 foo(){
   bar:
     if (whatever){
       cox()
     } else {
-      blah->
+      blah ->
         zoo
     }
 }
 ```
-and the caret is currently in the line with `zoo`, then the breadbrumbs would be:
-`foo(){`, `bar:`, `} else {`, and `blah->`.
 
-This approach is quite language agnostic, and I find it mostly usefull for code which spans many lines in which tracking indentation and context is difficult to me (for example in .sass files).
+With the caret at the line with `zoo`, the breadbrumbs would be:
+`foo(){`, `bar:`, `} else {`, and `blah ->`. The "crumbs" can be fine-tuned using a regex.
+
+This approach is language agnostic, can be quite usefull for code that spans many lines and when tracking indentation and context is difficult. It can also help you get your bearings after jumping into a large file (e.g. via search or goto).
 
 ## Installation
 
-The easiest way is to use [Package Control](https://packagecontrol.io/):
+We recommend using [Package Control](https://packagecontrol.io/):
 
-1. press CTRL+SHIFT+P (on Mac: CMD+SHIFT+P)
-2. type: "Package Control: Install Package"
-3. hit Enter
-4. type "Breadcrumbs"
-5. hit Enter
+1. Press CTRL+SHIFT+P (on Mac: CMD+SHIFT+P)
+2. Select "Package Control: Install Package"
+3. Search for "Breadcrumbs"
+4. Hit Enter
 
 ## Settings
 
@@ -35,16 +36,16 @@ You can edit Breadcrumbs.sublime-settings to specify the following values:
 
 | name | type | default value | meaning |
 |------|------|---------|---------|
-|"breadcrumb_length_limit" | Number | 100 | Trim each line to this many characters to form a breadcrumb |
-| "total_breadcrumbs_length_limit" | Number | 200 | Make sure that the total length of the status is no longer than this many characters, by trimming the longest breadcrumbs first |
-| "breadcrumbs_separator" | String | " › " | Separate breadcrumbs using this character |
+|"breadcrumb_length_limit" | Number | 100 | Trim each breadcrumb to this many characters |
+| "total_breadcrumbs_length_limit" | Number | 200 | Limit the total length of the breadcrumbs, by trimming the longest breadcrumbs first |
+| "breadcrumbs_separator" | String | " › " | Separate breadcrumbs using this string |
 | "breadcrumbs_regex" | String | "^\\s*(?P<name>.*\\S)" | Use only the part that matches the "name" group |
-| "breadcrumbs_statusbar" | Boolean | true | Optionally disable hide the breadcrumbs from the statusbar |
+| "breadcrumbs_statusbar" | Boolean | true | Optionally hide the breadcrumbs from the statusbar |
 
 ### Example regexes
 
-To only show Python classes and methods use:  
-`"^\\s*(def|class)\\s+(?P<name>.+)\\(.*"`
+- For Python classes and methods: `"^\\s*(def|class)\\s+(?P<name>.+)\\(.*"`
+- For JSON: `"^\\s*\"(?P<name>[^\"]+)\".*"`
 
 ### Example keybindings
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Breadcrumbs
-A plugin to Sublime Text 2 and Sublime Text 3, which adds breadcrumbs to the status bar based on scopes the current line belongs to. Alternatively, the breadcrumbs can be displayed inline using the Show Breadcrumbs command.
+A plugin to Sublime Text 2 and Sublime Text 3, which adds breadcrumbs to the status bar based on scopes the current line belongs to. Alternatively, the breadcrumbs can be displayed in a popup using the Show Breadcrumbs command.
 This is done based on indentation, by assuming that scopes are indented.
 
 For example if your code looks like this:

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ foo(){
     }
 }
 ```
-and the carret is currently in the line with `zoo`, then the breadbrumbs would be:
+and the caret is currently in the line with `zoo`, then the breadbrumbs would be:
 `foo(){`, `bar:`, `} else {`, and `blah->`.
 
 This approach is quite language agnostic, and I find it mostly usefull for code which spans many lines in which tracking indentation and context is difficult to me (for example in .sass files).
 
-## Instalation
+## Installation
 
 The easiest way is to use [Package Control](https://packagecontrol.io/):
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ You can edit Breadcrumbs.sublime-settings to specify the following values:
 |"breadcrumb_length_limit" | Number | 100 | Trim each breadcrumb to this many characters |
 | "total_breadcrumbs_length_limit" | Number | 200 | Limit the total length of the breadcrumbs, by trimming the longest breadcrumbs first |
 | "breadcrumbs_separator" | String | " › " | Separate breadcrumbs using this string |
-| "breadcrumbs_statusbar" | Boolean | true | Optionally hide the breadcrumbs from the statusbar |
+| "show_breadcrumbs_in_statusbar" | Boolean | true | Optionally hide the breadcrumbs from the statusbar |
+
+The `"show_breadcrumbs_in_statusbar"` setting can also be changed [per syntax](https://www.sublimetext.com/docs/3/settings.html), you can also turn it off globally and enable it only for specific languages (or projects even).
 
 ### Tuning the breadcrumbs with regular expressions
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ You can edit Breadcrumbs.sublime-settings to specify the following values:
 | "breadcrumbs_separator" | String | " › " | Separate breadcrumbs using this character |
 | "breadcrumbs_regex" | String | "(?P<name>.*)" | Use only the part that matches the "name" group |
 | "breadcrumbs_statusbar" | Boolean | true | Optionally disable hide the breadcrumbs from the statusbar |
+
+### Example regexes
+
+To only show Python classes and methods use:  
+`"^\\s*(def|class)\\s+(?P<name>.+)\\(.*"`

--- a/README.md
+++ b/README.md
@@ -32,31 +32,13 @@ We recommend using [Package Control](https://packagecontrol.io/):
 
 ## Settings
 
-You can edit Breadcrumbs.sublime-settings to specify the following values:
+The settings include values to limit the length of breadcrumbs and you can create your own regular expressions so it includes only what you need. Settings can be further customized [per syntax](https://www.sublimetext.com/docs/3/settings.html).
 
-| name | type | default value | meaning |
-|------|------|---------|---------|
-|"breadcrumb_length_limit" | Number | 100 | Trim each breadcrumb to this many characters |
-| "total_breadcrumbs_length_limit" | Number | 200 | Limit the total length of the breadcrumbs, by trimming the longest breadcrumbs first |
-| "breadcrumbs_separator" | String | " › " | Separate breadcrumbs using this string |
-| "show_breadcrumbs_in_statusbar" | Boolean | true | Optionally hide the breadcrumbs from the statusbar |
+Open Preferences > Package Settings > Breadcrumbs > Settings to view all options. 
 
-The `"show_breadcrumbs_in_statusbar"` setting can also be changed [per syntax](https://www.sublimetext.com/docs/3/settings.html), you can also turn it off globally and enable it only for specific languages (or projects even).
+### Example key bindings
 
-### Tuning the breadcrumbs with regular expressions
-
-This packages comes with a very basic regex (`"^\\s*(?P<name>.*\\S)"`) to clean up each breadcrumb. Only the part that matches the "name" group is used.
-
-You can create [Syntax Specific settings](https://www.sublimetext.com/docs/3/settings.html) to fine-tune it for each language you use. Some examples:
-
-- For Python  
-`"breadcrumb_regex": "(?i)^\\s*(def|class)\\s*(?P<name>[a-z0-9-_ ]+)\\b"`
-- For JSON  
-`"breadcrumb_regex": "^\\s*\"(?P<name>[^\"]+)\".*"`
-
-### Example keybindings
-
-This package doesn't provide keybindings for its commands, allowing you to customise them as you see fit. Here are some examples:
+This package doesn't provide key bindings for its commands, allowing you to customize them as you see fit. Here are some examples:
 
 ```json
 { "keys": ["super+ctrl+b"], "command": "breadcrumbs_popup" },


### PR DESCRIPTION
I was looking for something like this and am super glad to find your plugin and not have to figure this all out myself. I would like to make some additions and changes, let me know if you're willing to perhaps pull this into your package.

- a cleaner default separator `›`
- the ability to strip stuff from each "crumb" with a regex
- use `on_selection_modified_async`

I already have quite some stuff in my statusbar, and need to deal with lengthy paths. So I would like to have the option to display the breadcrumbs inline using phantoms. Also to save on performance I would then disable updating the statusbar at all. It would be even better to not register anything on `on_selection_modified_async` if the statusbar shouldn't be updated, but I don't know how to make that work.

The breadcrumbs now always start with the separator because the regex also makes it possible to clip out some steps. For instance to only show anything that starts with `class` or `def`. And that would show up as  `› ›` which is also lame. I bet if I sleep on it I can improve on that, although it doesn't look that bad now.

Anyway, let me know what you think or if you would like me to make some changes.

Edit: the phantoms are too simple to fully address #1, but it’s a start. Correct highlighting seems impossible or at least highly impractical to me, but more could be done with this than just dumping a string into it. E.g. it could be a list.